### PR TITLE
Preface `ArgumentOutOfRangeException` with `System.`

### DIFF
--- a/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
+++ b/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
@@ -330,7 +330,7 @@ Create a test method to verify correct behavior when the debit amount is less th
 
 ```csharp
 [TestMethod]
-[ExpectedException(typeof(ArgumentOutOfRangeException))]
+[ExpectedException(typeof(System.ArgumentOutOfRangeException))]
 public void Debit_WhenAmountIsLessThanZero_ShouldThrowArgumentOutOfRange()
 {
     // Arrange
@@ -383,12 +383,12 @@ Then, modify the two conditional statements in the `Debit` method:
 ```csharp
     if (amount > m_balance)
     {
-        throw new ArgumentOutOfRangeException("amount", amount, DebitAmountExceedsBalanceMessage);
+        throw new System.ArgumentOutOfRangeException("amount", amount, DebitAmountExceedsBalanceMessage);
     }
 
     if (amount < 0)
     {
-        throw new ArgumentOutOfRangeException("amount", amount, DebitAmountLessThanZeroMessage);
+        throw new System.ArgumentOutOfRangeException("amount", amount, DebitAmountLessThanZeroMessage);
     }
 ```
 
@@ -412,7 +412,7 @@ public void Debit_WhenAmountIsMoreThanBalance_ShouldThrowArgumentOutOfRange()
     {
         account.Debit(debitAmount);
     }
-    catch (ArgumentOutOfRangeException e)
+    catch (System.ArgumentOutOfRangeException e)
     {
         // Assert
         StringAssert.Contains(e.Message, BankAccount.DebitAmountExceedsBalanceMessage);
@@ -442,7 +442,7 @@ public void Debit_WhenAmountIsMoreThanBalance_ShouldThrowArgumentOutOfRange()
     {
         account.Debit(debitAmount);
     }
-    catch (ArgumentOutOfRangeException e)
+    catch (System.ArgumentOutOfRangeException e)
     {
         // Assert
         StringAssert.Contains(e.Message, BankAccount.DebitAmountExceedsBalanceMessage);


### PR DESCRIPTION
I have added an explicit invocation of `System` class library by using `System.` to preface the `ArgumentOutOfRangeException` which depend upon it.
Per the request of @gewarren here: https://github.com/MicrosoftDocs/visualstudio-docs/pull/3362#event-2389894774

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:
I am not sure if this counts as new or significantly updated, so I have not modified did you update the "ms.date" metadata